### PR TITLE
修改增加cookie的调用

### DIFF
--- a/sessionFile.go
+++ b/sessionFile.go
@@ -61,7 +61,8 @@ func (o *SessionFile) Set(c *Context, key string, value interface{}, expire time
 			Expires:  time.Now().Add(o.cookieExpire),
 			HttpOnly: true,
 		}
-		c.R.Header.Set("Cookie", ck.String())
+		c.R.AddCookie(ck)
+		// c.R.Header.Set("Cookie", ck.String())
 		http.SetCookie(c.W, ck)
 	}
 


### PR DESCRIPTION
调用AddCookie函数，不直接r.Header.Set。
因为直接r.Header.Set可能覆盖其他Cookie；

```go
func (r *Request) AddCookie(c *Cookie) {
	s := fmt.Sprintf("%s=%s", sanitizeCookieName(c.Name), sanitizeCookieValue(c.Value))
	if c := r.Header.Get("Cookie"); c != "" {
		r.Header.Set("Cookie", c+"; "+s)
	} else {
		r.Header.Set("Cookie", s)
	}
}
```